### PR TITLE
Allow binary content to pass through untouched with non-netty runtimes.

### DIFF
--- a/starters/micronaut/src/main/kotlin/br/com/zup/beagle/micronaut/filter/BeaglePlatformFilter.kt
+++ b/starters/micronaut/src/main/kotlin/br/com/zup/beagle/micronaut/filter/BeaglePlatformFilter.kt
@@ -46,7 +46,7 @@ class BeaglePlatformFilter(private val objectMapper: ObjectMapper) : OncePerRequ
     @Suppress("UNCHECKED_CAST")
     private fun treatResponse(wrappedResponse: MutableHttpResponse<*>, currentPlatform: String?) {
         wrappedResponse.body.ifPresent {
-            if (it !is NettySystemFileCustomizableResponseType && it !is String) {
+            if (it !is NettySystemFileCustomizableResponseType && it !is ByteArray && it !is String) {
                 val jsonTree = this.objectMapper.readTree(
                     this.objectMapper.writeValueAsString(it)
                 )


### PR DESCRIPTION
In lambda based runtimes, there isn't any netty involved so it comes back as binary data.
